### PR TITLE
Add initial in-memory chat history

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.6)
-      activesupport (= 7.0.6)
-    activerecord (7.0.6)
-      activemodel (= 7.0.6)
-      activesupport (= 7.0.6)
-    activesupport (7.0.6)
+    activemodel (7.1.2)
+      activesupport (= 7.1.2)
+    activerecord (7.1.2)
+      activemodel (= 7.1.2)
+      activesupport (= 7.1.2)
+      timeout (>= 0.4.0)
+    activesupport (7.1.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     dotenv (2.8.1)
-    faraday (2.7.10)
+    drb (2.2.0)
+      ruby2_keywords
+    event_stream_parser (1.0.0)
+    faraday (2.8.1)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-multipart (1.0.4)
@@ -21,25 +34,25 @@ GEM
     faraday-net_http (3.0.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.19.0)
+    minitest (5.20.0)
     multipart-post (2.3.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    neighbor (0.3.0)
+    mutex_m (0.2.0)
+    neighbor (0.3.2)
       activerecord (>= 6.1)
-    nio4r (2.5.9)
-    nokogiri (1.15.4-x86_64-darwin)
+    nio4r (2.7.0)
+    nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    pg (1.5.3)
-    puma (6.3.1)
+    pg (1.5.4)
+    puma (6.4.0)
       nio4r (~> 2.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rack-protection (3.1.0)
       rack (~> 2.2, >= 2.2.4)
-    ruby-openai (4.2.0)
+    ruby-openai (6.3.1)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby2_keywords (0.0.5)
@@ -48,13 +61,13 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.1.0)
       tilt (~> 2.0)
-    tilt (2.2.0)
+    tilt (2.3.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  x86_64-darwin-22
-  x86_64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   activerecord
@@ -70,4 +83,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.14
+   2.4.22

--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ require "sinatra"
 require_relative "src/open_ai_api"
 require_relative "src/document"
 require_relative "src/chunk"
+require_relative "src/chat_history"
 
 ActiveRecord::Base.establish_connection(
   adapter: ENV["DB_ADAPTER"],
@@ -16,7 +17,8 @@ ActiveRecord::Base.establish_connection(
   database: ENV["DB_NAME"],
 )
 
-open_ai_api = OpenAiApi.new
+enable :sessions
+chat_history = ChatHistory.new
 
 set :port, 3000
 
@@ -25,6 +27,7 @@ get "/" do
 end
 
 post "/" do
+  open_ai_api = OpenAiApi.new(session[:session_id], chat_history)
   @reply = open_ai_api.ask_question(params[:prompt])
   erb :index
 end

--- a/src/chat_history.rb
+++ b/src/chat_history.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Simple Key-Value store, where the key is the session-id and the value is
+#   the chat history between the user and the AI, as an array of hashes.
+
+require 'openai'
+
+class ChatHistory
+  HISTORY_LIMIT = 10
+
+  def initialize
+    @messages = {}
+  end
+
+  def truncated_message_history(session_id, token_limit)
+    token_count = 0
+    message_history(session_id).take_while do |message|
+      token_count += OpenAI.rough_token_count(message[:content])
+      token_count <= token_limit
+    end.reverse
+  end
+
+  def add_user_message(session_id, content)
+    message = { role: 'user', content: }
+    add_message(session_id, message)
+  end
+
+  def add_assistant_message(session_id, content)
+    message = { role: 'assistant', content: }
+    add_message(session_id, message)
+  end
+
+  private
+
+  attr_reader :messages
+
+  def add_message(session_id, message)
+    session_messages = message_history(session_id)
+    return @messages[session_id] = [message] if session_messages.blank?
+
+    dequeue(session_id) if session_messages.length == HISTORY_LIMIT
+    enqueue(session_id, message)
+  end
+
+  def dequeue(session_id)
+    @messages[session_id].pop
+  end
+
+  def enqueue(session_id, message)
+    @messages[session_id].unshift(message)
+  end
+
+  def message_history(session_id)
+    messages[session_id]
+  end
+end

--- a/src/open_ai_api.rb
+++ b/src/open_ai_api.rb
@@ -1,18 +1,31 @@
+# frozen_string_literal: true
+
 require "openai"
 
 class OpenAiApi
+  OPEN_AI_TOKEN_LIMIT = 4096
+  SYSTEM_MESSAGE = <<~CONTENT
+    Answer the current Question: based on the latest Context:
+    Take into account the the previous message history.
+    If the question can't be answered based on the context, say \"I dunno!\".
+  CONTENT
+
+  def initialize(session_id, chat_history)
+    @session_id = session_id
+    @chat_history = chat_history
+  end
+
   def ask_question(question)
     context = create_context(Document, question)
     # context = create_context(Chunk, question)
 
-    prompt = <<~CONTENT
-      Answer the question based on the context below.
-      If the question can't be answered based on the context, say \"I dunno!\".
-      Context: #{context}
-      Question: #{question}
-    CONTENT
+    prompt = "Context: #{context} Question: #{question}"
+    chat_history.add_user_message(session_id, prompt)
 
-    get_answer_to_question(prompt)
+    answer = get_answer_to_question
+    chat_history.add_assistant_message(session_id, answer)
+
+    answer
   end
 
   def get_embedding_for(text)
@@ -24,6 +37,10 @@ class OpenAiApi
     ).dig("data", 0, "embedding")
   end
 
+  private
+
+  attr_reader :chat_history, :session_id
+
   def create_context(klass, question)
     klass.nearest_neighbors(
       :embedding,
@@ -32,15 +49,26 @@ class OpenAiApi
     ).first(1).map(&:content)
   end
 
-  def get_answer_to_question(prompt)
+  def get_answer_to_question
     answer = client.chat(
       parameters: {
         model: ENV["CHAT_MODEL"],
-        messages: [{ role: "user", content: prompt }],
+        messages: [
+          { role: 'system', content: SYSTEM_MESSAGE },
+          *message_history
+        ],
         temperature: ENV["CHAT_TEMPERATURE"].to_f
       }
     )
     answer.dig("choices", 0, "message", "content") || answer.dig("error", "message")
+  end
+
+  def message_history
+    chat_history.truncated_message_history(session_id, token_limit)
+  end
+
+  def token_limit
+    OPEN_AI_TOKEN_LIMIT - OpenAI.rough_token_count(SYSTEM_MESSAGE)
   end
 
   def client

--- a/src/vector_database.rb
+++ b/src/vector_database.rb
@@ -2,7 +2,7 @@ class VectorDatabase
   attr_reader :open_ai_api
 
   def initialize
-    @open_ai_api = OpenAiApi.new
+    @open_ai_api = OpenAiApi.new(nil, nil)
   end
 
   def load_content(klass, content, content_source, document = nil)


### PR DESCRIPTION
- In memory key-value store that can store up to 10 messages by default.
- This initial truncation strategy will only send the last n messages to openAI that don't exceed the token limit
- Chat history is tracked by session_id
- As it is currently, it does not clear/flush message histories (not recommened for prod envs). We need to create a way of flushing old histories based on a specified time limit. But this is a spike of how it can be done using a product like redis (see below).

TODO in the main app:
- Use Redis if we want anonymity, and don't want to keep the history permanently. There can be an expiration time limit in redis too.
- Use postgres (any DB) for permanent storage of histories.